### PR TITLE
Use uv build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = []
-license = { file = "LICENSE" }
+license = "GPL-3.0-only"
+license-files = ["LICENSE"]
 keywords = ["webfinger", "rfc7033", "jrd", "discovery"]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -25,14 +26,8 @@ Homepage = "https://github.com/Codex/webfinger-generator"
 Repository = "https://github.com/Codex/webfinger-generator"
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[tool.hatch.build.targets.wheel]
-packages = ["src/webfinger_generator"]
-
-[tool.hatch.build.targets.sdist]
-include = ["src/webfinger_generator", "README.md", "LICENSE", "pyproject.toml"]
+requires = ["uv_build>=0.7.22,<0.8"]
+build-backend = "uv_build"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary
- switch the project build system to the uv build backend and drop hatch-specific configuration
- declare the GPLv3 license via SPDX identifier while keeping the LICENSE file packaged

## Testing
- uv run --group dev pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0ff96fc2883228b5c7a0b7dbbba83