### PR TITLE
Enforce RFC 7033 validation rules

### DIFF
--- a/src/webfinger_generator/jrd.py
+++ b/src/webfinger_generator/jrd.py
@@ -6,6 +6,7 @@ import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Mapping, Sequence
+from urllib.parse import urlparse
 
 __all__ = [
     "JRD",
@@ -20,36 +21,93 @@ class JRDValidationError(ValueError):
 
 
 def _require_string(value: Any, *, field: str) -> str:
-    if not isinstance(value, str) or not value:
+    if not isinstance(value, str):
         raise JRDValidationError(f"{field} must be a non-empty string.")
+
+    if not value:
+        raise JRDValidationError(f"{field} must be a non-empty string.")
+
+    if value != value.strip():
+        raise JRDValidationError(
+            f"{field} must not contain leading or trailing whitespace."
+        )
+
     return value
 
 
-def _validate_string_sequence(name: str, values: Sequence[str]) -> tuple[str, ...]:
+def _require_uri(value: Any, *, field: str) -> str:
+    candidate = _require_string(value, field=field)
+    parsed = urlparse(candidate)
+
+    if not parsed.scheme:
+        raise JRDValidationError(f"{field} must be an absolute URI with a scheme.")
+
+    if not (parsed.netloc or parsed.path):
+        raise JRDValidationError(f"{field} must contain a URI path or authority component.")
+
+    if parsed.scheme in {"http", "https"} and not parsed.netloc:
+        raise JRDValidationError(f"{field} must include a network location component.")
+
+    return candidate
+
+
+def _validate_string_sequence(
+    name: str,
+    values: Sequence[str],
+    *,
+    require_uri: bool = False,
+) -> tuple[str, ...]:
     if not isinstance(values, Sequence) or isinstance(values, (str, bytes)):
         raise JRDValidationError(f"{name} must be a sequence of strings.")
 
     cleaned: list[str] = []
     for idx, value in enumerate(values):
+        if require_uri:
+            cleaned.append(_require_uri(value, field=f"{name}[{idx}]"))
+            continue
+
         if not isinstance(value, str) or not value:
             raise JRDValidationError(
                 f"{name} must contain only non-empty strings (item {idx} was {value!r})."
+            )
+        if value != value.strip():
+            raise JRDValidationError(
+                f"{name}[{idx}] must not contain leading or trailing whitespace."
             )
         cleaned.append(value)
     return tuple(cleaned)
 
 
-def _validate_string_mapping(name: str, mapping: Mapping[str, str]) -> dict[str, str]:
+def _validate_string_mapping(
+    name: str, mapping: Mapping[str, str], *, require_uri_keys: bool = False
+) -> dict[str, str]:
     if not isinstance(mapping, Mapping):
         raise JRDValidationError(f"{name} must be a mapping of string keys to string values.")
 
     cleaned: dict[str, str] = {}
     for key, value in mapping.items():
-        if not isinstance(key, str) or not key:
-            raise JRDValidationError(f"{name} keys must be non-empty strings (got {key!r}).")
+        if require_uri_keys:
+            validated_key = _require_uri(key, field=f"{name} key")
+        else:
+            if not isinstance(key, str) or not key:
+                raise JRDValidationError(
+                    f"{name} keys must be non-empty strings (got {key!r})."
+                )
+            if key != key.strip():
+                raise JRDValidationError(
+                    f"{name} keys must not contain leading or trailing whitespace."
+                )
+            validated_key = key
+
         if not isinstance(value, str):
-            raise JRDValidationError(f"{name} values must be strings (key {key!r} had {value!r}).")
-        cleaned[key] = value
+            raise JRDValidationError(
+                f"{name} values must be strings (key {validated_key!r} had {value!r})."
+            )
+        if value != value.strip():
+            raise JRDValidationError(
+                f"{name} values must not contain leading or trailing whitespace (key {validated_key!r})."
+            )
+        cleaned[validated_key] = value
     return cleaned
 
 
@@ -69,6 +127,16 @@ def _format_rfc3339(dt: datetime) -> str:
     return dt.isoformat().replace("+00:00", "Z")
 
 
+def _validate_rfc3339_string(value: str, *, field: str) -> None:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise JRDValidationError(f"{field} must be an RFC 3339 formatted timestamp.") from exc
+
+    if parsed.tzinfo is None:
+        raise JRDValidationError(f"{field} must include a timezone offset.")
+
+
 @dataclass(slots=True)
 class Link:
     """A single WebFinger link description."""
@@ -84,17 +152,21 @@ class Link:
     def __post_init__(self) -> None:
         self.rel = _require_string(self.rel, field="rel")
 
-        if self.href is not None and not isinstance(self.href, str):
-            raise JRDValidationError("href must be a string when provided.")
-        if self.template is not None and not isinstance(self.template, str):
-            raise JRDValidationError("template must be a string when provided.")
+        if self.href is not None:
+            self.href = _require_uri(self.href, field="href")
+        if self.template is not None:
+            self.template = _require_uri(self.template, field="template")
         if self.href and self.template:
             raise JRDValidationError("A link cannot contain both 'href' and 'template'.")
+        if self.href is None and self.template is None:
+            raise JRDValidationError("A link must contain either 'href' or 'template'.")
 
         if self.titles is not None:
             self.titles = _validate_string_mapping("titles", self.titles)
         if self.properties is not None:
-            self.properties = _validate_string_mapping("properties", self.properties)
+            self.properties = _validate_string_mapping(
+                "properties", self.properties, require_uri_keys=True
+            )
         if self.hreflang is not None:
             self.hreflang = _validate_string_sequence("hreflang", self.hreflang)
 
@@ -121,7 +193,7 @@ class Link:
 class JRD:
     """Representation of a JSON Resource Descriptor."""
 
-    subject: str | None = None
+    subject: str
     aliases: Sequence[str] | None = None
     properties: Mapping[str, str] | None = None
     links: Sequence[Mapping[str, Any] | Link] | None = None
@@ -129,14 +201,17 @@ class JRD:
     additional_members: Mapping[str, Any] | None = None
 
     def __post_init__(self) -> None:
-        if self.subject is not None:
-            self.subject = _require_string(self.subject, field="subject")
+        self.subject = _require_uri(self.subject, field="subject")
 
         if self.aliases is not None:
-            self.aliases = _validate_string_sequence("aliases", self.aliases)
+            self.aliases = _validate_string_sequence(
+                "aliases", self.aliases, require_uri=True
+            )
 
         if self.properties is not None:
-            self.properties = _validate_string_mapping("properties", self.properties)
+            self.properties = _validate_string_mapping(
+                "properties", self.properties, require_uri_keys=True
+            )
 
         if self.links is not None:
             if not isinstance(self.links, Sequence) or isinstance(self.links, (str, bytes)):
@@ -148,8 +223,10 @@ class JRD:
 
         if self.expires is not None and not isinstance(self.expires, (datetime, str)):
             raise JRDValidationError("expires must be a datetime or RFC 3339 formatted string.")
-        if isinstance(self.expires, str) and not self.expires:
-            raise JRDValidationError("expires strings must be non-empty.")
+        if isinstance(self.expires, str):
+            if not self.expires:
+                raise JRDValidationError("expires strings must be non-empty.")
+            _validate_rfc3339_string(self.expires, field="expires")
 
         if self.additional_members is not None:
             if not isinstance(self.additional_members, Mapping):
@@ -160,6 +237,10 @@ class JRD:
                     raise JRDValidationError(
                         f"additional_members keys must be non-empty strings (got {key!r})."
                     )
+                if key != key.strip():
+                    raise JRDValidationError(
+                        f"additional_members keys must not contain leading or trailing whitespace."
+                    )
                 if key in {"subject", "aliases", "properties", "links", "expires"}:
                     raise JRDValidationError(
                         f"additional member '{key}' conflicts with a standard JRD member."
@@ -167,17 +248,6 @@ class JRD:
                 cleaned[key] = value
             self.additional_members = cleaned
 
-        if not any(
-            (
-                self.subject,
-                self.aliases,
-                self.properties,
-                self.links,
-            )
-        ):
-            raise JRDValidationError(
-                "A JRD must contain at least one of subject, aliases, properties, or links."
-            )
 
     def to_dict(self) -> dict[str, Any]:
         """Convert the descriptor into a dictionary."""
@@ -208,7 +278,7 @@ class JRD:
 
 
 def generate_jrd(
-    subject: str | None = None,
+    subject: str,
     *,
     aliases: Sequence[str] | None = None,
     properties: Mapping[str, str] | None = None,
@@ -218,7 +288,18 @@ def generate_jrd(
     indent: int | None = None,
     ensure_ascii: bool = False,
 ) -> str:
-    """Convenience wrapper that returns a JSON document for the supplied data."""
+    """Convenience wrapper that returns a JSON document for the supplied data.
+
+    Args:
+        subject: Absolute URI identifying the WebFinger resource.
+        aliases: Optional sequence of URI aliases.
+        properties: Optional mapping of property URI keys to string values.
+        links: Optional sequence of :class:`Link` instances or link mappings.
+        expires: Optional datetime or RFC 3339 timestamp string.
+        additional_members: Optional mapping of extension members.
+        indent: Number of spaces to indent the generated JSON.
+        ensure_ascii: Whether JSON output should escape non-ASCII characters.
+    """
 
     descriptor = JRD(
         subject=subject,

--- a/tests/test_jrd.py
+++ b/tests/test_jrd.py
@@ -13,9 +13,24 @@ def test_link_href_and_template_are_mutually_exclusive() -> None:
         Link(rel="self", href="https://example.com", template="https://example.com/{uri}")
 
 
-def test_jrd_requires_content() -> None:
+def test_jrd_requires_subject() -> None:
     with pytest.raises(JRDValidationError):
-        JRD()
+        JRD(subject="")
+
+
+def test_subject_must_be_uri() -> None:
+    with pytest.raises(JRDValidationError):
+        JRD(subject="not-a-uri")
+
+
+def test_aliases_must_be_uris() -> None:
+    with pytest.raises(JRDValidationError):
+        JRD(subject="acct:carol@example.com", aliases=["not-a-uri"])
+
+
+def test_property_keys_must_be_uris() -> None:
+    with pytest.raises(JRDValidationError):
+        JRD(subject="acct:carol@example.com", properties={"name": "Alice"})
 
 
 def test_jrd_to_dict_round_trip() -> None:
@@ -65,3 +80,24 @@ def test_generate_jrd_accepts_mappings_for_links() -> None:
 def test_alias_validation_rejects_empty_strings() -> None:
     with pytest.raises(JRDValidationError):
         JRD(subject="acct:carol@example.com", aliases=[""])
+
+
+def test_link_requires_href_or_template() -> None:
+    with pytest.raises(JRDValidationError):
+        Link(rel="self")
+
+
+def test_link_href_must_be_uri() -> None:
+    with pytest.raises(JRDValidationError):
+        Link(rel="self", href="not a uri")
+
+
+def test_expires_string_must_be_rfc3339() -> None:
+    with pytest.raises(JRDValidationError):
+        JRD(subject="acct:dan@example.com", expires="2024-01-01T12:30:00")
+
+
+def test_minimal_jrd_serialises_subject_only() -> None:
+    descriptor = JRD(subject="acct:erin@example.com")
+
+    assert descriptor.to_dict() == {"subject": "acct:erin@example.com"}


### PR DESCRIPTION
## Summary
- require WebFinger subjects, aliases, link targets, and property keys to be absolute URIs per RFC 7033
- tighten string handling, RFC 3339 expiration parsing, and conflict checks when building JRDs
- extend the test suite with coverage for the new validation paths and minimal descriptor support

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d102119d048322be8e52715a6c5e0c